### PR TITLE
feat(kprompt): add kprompt-bin, kprompt-git and kprompt-dash-git

### DIFF
--- a/packages/kprompt-bin/PKGBUILD
+++ b/packages/kprompt-bin/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: Zadkiel AHARONIAN <hello@zadkiel.fr>
+# Repository: https://github.com/aslafy-z/aur-packages
+
+pkgname=kprompt-bin
+pkgver=0.6.0 # renovate: datasource=github-releases depName=kprompt packageName=kprompt/kprompt
+pkgrel=1
+pkgdesc='AI Kubernetes CLI: natural language to a reviewable plan, applied after approval'
+arch=('x86_64' 'aarch64')
+url='https://kprompt.ai'
+license=('Apache-2.0')
+provides=("kprompt=${pkgver}")
+conflicts=('kprompt')
+optdepends=('helm: plan Helm chart installs and upgrades')
+options=('!strip' '!debug')
+# The release archives omit the NOTICE file, which Apache-2.0 section 4(d)
+# requires redistributions to carry, so it is fetched from the tag directly.
+source=("kprompt-${pkgver}-NOTICE::https://raw.githubusercontent.com/kprompt/kprompt/v${pkgver}/NOTICE")
+source_x86_64=("https://github.com/kprompt/kprompt/releases/download/v${pkgver}/kprompt_${pkgver}_linux_amd64.tar.gz")
+source_aarch64=("https://github.com/kprompt/kprompt/releases/download/v${pkgver}/kprompt_${pkgver}_linux_arm64.tar.gz")
+sha256sums=('3513bb19225b1e4d2f6ee1f8e5247b62063cefc71bd513beef65afc1e0f39150')
+sha256sums_x86_64=('baadb3b46a2e03e0b85fd8cb6d92947a149b83c63bd094216be66ee42cb57069')
+sha256sums_aarch64=('37eb519c1e10e746bf4585acc5fe501e61491b74505f93e02f378549def25c0e')
+
+package() {
+    install -D -m755 "${srcdir}/kprompt" "${pkgdir}/usr/bin/kprompt"
+
+    install -D -m644 "${srcdir}/LICENSE" \
+        "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+    install -D -m644 "${srcdir}/kprompt-${pkgver}-NOTICE" \
+        "${pkgdir}/usr/share/licenses/${pkgname}/NOTICE"
+    install -D -m644 "${srcdir}/README.md" \
+        "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+
+    local _shell
+    for _shell in bash zsh fish; do
+        "${srcdir}/kprompt" completion "${_shell}" > "${srcdir}/completion.${_shell}"
+    done
+
+    install -D -m644 "${srcdir}/completion.bash" \
+        "${pkgdir}/usr/share/bash-completion/completions/kprompt"
+    install -D -m644 "${srcdir}/completion.zsh" \
+        "${pkgdir}/usr/share/zsh/site-functions/_kprompt"
+    install -D -m644 "${srcdir}/completion.fish" \
+        "${pkgdir}/usr/share/fish/vendor_completions.d/kprompt.fish"
+}

--- a/packages/kprompt-dash-git/PKGBUILD
+++ b/packages/kprompt-dash-git/PKGBUILD
@@ -1,0 +1,62 @@
+# Maintainer: Zadkiel AHARONIAN <hello@zadkiel.fr>
+# Repository: https://github.com/aslafy-z/aur-packages
+
+# No `# renovate:` annotation: pkgver() derives the version from the checkout at
+# build time, so there is no pinned version for Renovate to bump.
+pkgname=kprompt-dash-git
+_pkgname=kprompt-dash
+pkgver=0.1.0.r0.g96f5e58
+pkgrel=1
+pkgdesc='Localhost read-only Kubernetes inventory UI for kprompt'
+arch=('x86_64' 'aarch64')
+url='https://github.com/kprompt/kprompt-dash'
+license=('Apache-2.0')
+depends=('glibc')
+makedepends=('git' 'go')
+provides=("kprompt-dash=${pkgver%%.r*}")
+conflicts=('kprompt-dash')
+optdepends=('xdg-utils: open the UI in a browser with --open')
+# -trimpath rewrites every source path out of the binary, leaving the debug
+# package with an empty usr/src/debug and a build-id symlink to nothing.
+options=('!debug')
+source=("${_pkgname}::git+https://github.com/kprompt/kprompt-dash.git")
+sha256sums=('SKIP')
+
+pkgver() {
+    cd "${srcdir}/${_pkgname}"
+
+    git describe --long --tags --abbrev=7 |
+        sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+build() {
+    cd "${srcdir}/${_pkgname}"
+
+    # Upstream builds with CGO disabled. Arch's Go packaging guidelines are
+    # followed instead, so the binary gets the distribution hardening flags.
+    export CGO_CPPFLAGS="${CPPFLAGS}"
+    export CGO_CFLAGS="${CFLAGS}"
+    export CGO_CXXFLAGS="${CXXFLAGS}"
+    export CGO_LDFLAGS="${LDFLAGS}"
+    export GOFLAGS='-buildmode=pie -trimpath -mod=readonly -modcacherw'
+
+    go build \
+        -ldflags '-linkmode=external' \
+        -o build/kprompt-dash \
+        ./cmd/kprompt-dash
+}
+
+check() {
+    cd "${srcdir}/${_pkgname}"
+
+    go test ./...
+}
+
+package() {
+    cd "${srcdir}/${_pkgname}"
+
+    install -D -m755 build/kprompt-dash "${pkgdir}/usr/bin/kprompt-dash"
+
+    install -D -m644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+    install -D -m644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+}

--- a/packages/kprompt-git/PKGBUILD
+++ b/packages/kprompt-git/PKGBUILD
@@ -1,0 +1,75 @@
+# Maintainer: Zadkiel AHARONIAN <hello@zadkiel.fr>
+# Repository: https://github.com/aslafy-z/aur-packages
+
+# No `# renovate:` annotation: pkgver() derives the version from the checkout at
+# build time, so there is no pinned version for Renovate to bump.
+pkgname=kprompt-git
+_pkgname=kprompt
+pkgver=0.6.0.r10.g7e73ecd
+pkgrel=1
+pkgdesc='AI Kubernetes CLI: natural language to a reviewable plan, applied after approval'
+arch=('x86_64' 'aarch64')
+url='https://kprompt.ai'
+license=('Apache-2.0')
+depends=('glibc')
+makedepends=('git' 'go')
+provides=("kprompt=${pkgver%%.r*}")
+conflicts=('kprompt')
+optdepends=('helm: plan Helm chart installs and upgrades')
+# -trimpath rewrites every source path out of the binary, leaving the debug
+# package with an empty usr/src/debug and a build-id symlink to nothing.
+options=('!debug')
+source=("${_pkgname}::git+https://github.com/kprompt/kprompt.git")
+sha256sums=('SKIP')
+
+pkgver() {
+    cd "${srcdir}/${_pkgname}"
+
+    git describe --long --tags --abbrev=7 |
+        sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+build() {
+    cd "${srcdir}/${_pkgname}"
+
+    # Upstream builds with CGO disabled. Arch's Go packaging guidelines are
+    # followed instead, so the binary gets the distribution hardening flags.
+    export CGO_CPPFLAGS="${CPPFLAGS}"
+    export CGO_CFLAGS="${CFLAGS}"
+    export CGO_CXXFLAGS="${CXXFLAGS}"
+    export CGO_LDFLAGS="${LDFLAGS}"
+    export GOFLAGS='-buildmode=pie -trimpath -mod=readonly -modcacherw'
+
+    go build \
+        -ldflags "-linkmode=external -X main.version=${pkgver}" \
+        -o build/kprompt \
+        ./cmd/kprompt
+}
+
+check() {
+    cd "${srcdir}/${_pkgname}"
+
+    go test ./...
+}
+
+package() {
+    cd "${srcdir}/${_pkgname}"
+
+    install -D -m755 build/kprompt "${pkgdir}/usr/bin/kprompt"
+
+    install -D -m644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+    install -D -m644 NOTICE "${pkgdir}/usr/share/licenses/${pkgname}/NOTICE"
+    install -D -m644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+
+    local _shell
+    for _shell in bash zsh fish; do
+        build/kprompt completion "${_shell}" > "build/completion.${_shell}"
+    done
+
+    install -D -m644 build/completion.bash \
+        "${pkgdir}/usr/share/bash-completion/completions/kprompt"
+    install -D -m644 build/completion.zsh \
+        "${pkgdir}/usr/share/zsh/site-functions/_kprompt"
+    install -D -m644 build/completion.fish \
+        "${pkgdir}/usr/share/fish/vendor_completions.d/kprompt.fish"
+}


### PR DESCRIPTION
Adds three packages for [kprompt](https://github.com/kprompt/kprompt), an AI
Kubernetes CLI that turns a prompt into a reviewable plan and only mutates the
cluster after approval, plus its companion read-only dashboard. None of the
three names exist on the AUR today.

## kprompt-bin

Repackages the upstream goreleaser archives for `x86_64` and `aarch64`. The
binaries are static (`CGO_ENABLED=0`) and already stripped, so there are no
`depends` and `options=('!strip' '!debug')`.

The release archives ship `LICENSE` and `README.md` but omit `NOTICE`, which
Apache-2.0 section 4(d) requires redistributions to carry, so `NOTICE` is
fetched from the tag as a separate architecture-independent source. That is the
reason there is both a `sha256sums` array and the per-architecture ones.

The `# renovate:` annotation points at `github-releases` for `kprompt/kprompt`,
and all three checksum arrays were filled by `mise run pkg:refresh`.

## kprompt-git

Builds `main` from source. `pkgver()` derives the version with `git describe`,
so there is no pinned version and deliberately no `# renovate:` annotation.

Upstream builds with CGO disabled; this follows Arch's Go packaging guidelines
instead so the binary picks up the distribution hardening flags. The result is a
PIE executable linked only against `libc.so.6`, hence `depends=('glibc')`.
`-trimpath` leaves the split debug package with an empty `usr/src/debug` and a
dangling build-id symlink, so `options=('!debug')` suppresses it.

`check()` runs `go test ./...`.

## kprompt-dash-git

Builds `main` of [kprompt-dash](https://github.com/kprompt/kprompt-dash), a
separate repository holding a localhost read-only Kubernetes inventory UI. It
installs `/usr/bin/kprompt-dash`, so it neither collides with nor depends on the
`kprompt` packages; the CLI has its own built-in `dash` subcommand.

Same shape as `kprompt-git`, with three differences that follow from upstream:
it uses plain `flag` rather than cobra, so there are no completions to generate;
there is no version variable, so nothing is stamped through `-ldflags`; and the
repository carries no `NOTICE`, so only `LICENSE` is installed. `optdepends`
lists `xdg-utils`, which `--open` shells out to on Linux.

Upstream has a single release, `v0.1.0`, and `HEAD` currently sits on that tag.

## Common to the kprompt packages

`provides=kprompt=<version>` and `conflicts=kprompt`, so `kprompt-bin` and
`kprompt-git` are interchangeable and a future source package can take the plain
name. `optdepends` lists `helm`, the only external binary kprompt probes for;
the Kubernetes client is in-process, so `kubectl` is not required.

Both install the binary, `LICENSE`, `NOTICE`, `README.md`, and bash/zsh/fish
completions generated from cobra at package time.

## Validation

`mise run pkg:build` on all three, on `x86_64`:

- `kprompt-bin` builds; namcap reports only `lacks FULL RELRO` and `lacks PIE`,
  both inherent to the prebuilt static binary and not fixable without rebuilding,
  which is what `kprompt-git` is for.
- `kprompt-git` and `kprompt-dash-git` build, their test suites pass, and namcap
  is silent on both.
- `mise run lint` passes.
- `kprompt version` from the `kprompt-git` build reports the derived `pkgver`.
- `kprompt-bin` and `kprompt-dash-git` were installed with `pacman -U` and both
  binaries run.

`aarch64` is declared but was not built; only the `x86_64` sources were exercised.

## Notes

`makepkg` rewrites `pkgver=` in the PKGBUILD of both `-git` packages on every
build, so the version published to the AUR will be whatever `main` resolves to
at build time while the value tracked here stays as committed. That is normal
for a VCS package, but it does mean the weekly scheduled run republishes them
whenever upstream has moved.
