### PR TITLE
ci(build): build only the packages a change touches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
       - name: Generate matrix
         id: gen-matrix
+        env:
+          EVENT: ${{ github.event_name }}
+          PR_BASE: ${{ github.base_ref }}
+          PUSH_BEFORE: ${{ github.event.before }}
+        # Scheduled and manual runs pass no base ref, so they build everything.
+        # That is the point of the weekly run: catching upstream breakage in
+        # packages nobody has touched, and retrying any publish that failed.
         run: |
-          packages=$(find packages -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort | jq -R . | jq -cs .)
-          echo "packages=$packages" >> "$GITHUB_OUTPUT"
+          case "$EVENT" in
+              pull_request) base="origin/$PR_BASE" ;;
+              push) base="$PUSH_BEFORE" ;;
+              *) base="" ;;
+          esac
+          echo "packages=$(scripts/changed-packages.sh "$base")" >> "$GITHUB_OUTPUT"
     outputs:
       packages: ${{ steps.gen-matrix.outputs.packages }}
 
   aur:
     runs-on: ubuntu-latest
     needs: generate-matrix
+    # An empty matrix vector fails the workflow instead of skipping the job, and
+    # a change touching no package at all leaves nothing to build.
+    if: needs.generate-matrix.outputs.packages != '[]'
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 Personal AUR packages, managed in a GitHub repository.
 
-- Packages are built and validated with `namcap` in a clean container on every
-  pull request, on every push to `main`, and weekly.
-- Pushes to `main` publish to the AUR. Nothing else does.
+- Pull requests and pushes to `main` build and `namcap`-validate only the
+  packages they touch, in a clean container. A change to the CI workflow or to
+  `scripts/` builds every package instead, as do the weekly and manual runs.
+- Anything running on `main` publishes to the AUR; pull requests never do. The
+  weekly run is therefore also what retries a publish that failed.
 - Renovate opens pull requests for new upstream versions, with checksums for
   every architecture already recomputed in the same commit.
 - `.SRCINFO` is generated in CI and is not tracked here.

--- a/scripts/changed-packages.sh
+++ b/scripts/changed-packages.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Selects the packages CI should build and prints them as a JSON array.
+#
+# Given no base ref, or one that no longer resolves after a force push, every
+# package is selected. Otherwise selection is limited to the packages whose own
+# files differ from the base ref.
+set -euo pipefail
+
+# Paths CI actually executes. A change to any of them can alter how every
+# package is built, so it invalidates per-package selection. mise.toml and the
+# repository docs are deliberately absent: nothing in the build path reads them.
+readonly TOOLING_PATTERN='^(\.github/workflows/ci\.yml|scripts/)'
+
+list_all() {
+    find packages -mindepth 1 -maxdepth 1 -type d -printf '%f\n'
+}
+
+list_changed() {
+    local base=$1 changed pkg
+
+    # Three-dot, so the comparison starts at the merge base rather than at the
+    # tip of the base branch. On a pull request that excludes commits landed on
+    # the base since the branch diverged.
+    changed=$(git diff --name-only "${base}...HEAD")
+
+    if grep -qE "$TOOLING_PATTERN" <<<"$changed"; then
+        list_all
+        return
+    fi
+
+    # Deleted and renamed-away packages still show up in the diff. Only the ones
+    # surviving in the worktree can be handed to makepkg.
+    while IFS= read -r pkg; do
+        if [[ -d "packages/$pkg" ]]; then
+            echo "$pkg"
+        fi
+    done < <(sed -n 's|^packages/\([^/]*\)/.*|\1|p' <<<"$changed")
+}
+
+base=${1-}
+
+if [[ -n $base ]] && git rev-parse --verify --quiet "${base}^{commit}" >/dev/null; then
+    list_changed "$base"
+else
+    list_all
+fi | sort -u | jq -R . | jq -cs .


### PR DESCRIPTION
## What

CI no longer builds every package on every run. Pull requests and pushes to
`main` now build only the packages whose files actually changed.

## Why

The matrix was the full contents of `packages/`, so each change cost one build
per package on the pull request and another full set on the merge. That scales
linearly with the number of packages on every single Renovate bump, and this
repository is meant to grow.

## How

`scripts/changed-packages.sh` takes an optional base ref and prints the JSON
array the matrix consumes:

- No base ref, or one that does not resolve, selects every package.
- Otherwise it diffs three-dot against the base ref, so the comparison starts
  at the merge base rather than the tip of the base branch.
- A change touching `.github/workflows/ci.yml` or `scripts/` selects every
  package, since either can alter how any package is built.
- Otherwise `packages/<name>/...` maps to `<name>`, and names whose directory
  no longer exists in the worktree are dropped, so a deleted or renamed-away
  package is never handed to `makepkg`.

`ci.yml` maps the event to a base ref and calls the script:

| Trigger | Base ref | Selection |
| --- | --- | --- |
| `pull_request` | `origin/$base_ref` | changed only |
| `push` to `main` | `github.event.before` | changed only |
| `schedule`, `workflow_dispatch` | none | all |

The weekly run stays a full sweep. It is what catches upstream breakage in
packages nobody touched, and, because the publish guard admits any non-pull-request
event on `main`, it is also what retries a publish that failed.

The `generate-matrix` checkout gains `fetch-depth: 0`, needed for `origin/<base>`
to exist and for the merge base to resolve. The `aur` job gains
`if: needs.generate-matrix.outputs.packages != '[]'`, because an empty matrix
vector fails the workflow rather than skipping the job.

Keeping the logic in `scripts/` rather than inline in YAML puts it under
`mise run lint` and makes it runnable locally: `scripts/changed-packages.sh origin/main`.

## Effects

A Renovate pull request bumping one package builds that package instead of all
of them, and the merge does the same. A pull request touching only `README.md`
builds nothing and the `aur` job is skipped. Publishing is unchanged: the guard,
the deploy action and the commit message all behave exactly as before, and
rebuilding an untouched package never published anything anyway because the
deploy action commits only on a real diff.

## Validation

`mise run lint` passes. The script was exercised against real commits in a
throwaway clone:

| Case | Result |
| --- | --- |
| One package touched | that package only |
| Both packages touched | both |
| `README.md` or `mise.toml` only | `[]`, job skipped |
| `ci.yml` touched | all |
| `scripts/*.sh` touched | all |
| Package deleted | `[]`, no dead matrix entry |
| Package renamed | new name only |
| New package added | the new package only |
| No base ref / all-zeros / unresolvable ref | all |

This pull request touches both `ci.yml` and `scripts/`, so it exercises the
tooling fallback and builds every package. The narrowing shows up on the first
package-only pull request after the merge.

## Risks and follow-ups

Failure is biased towards building too much: an unresolvable base ref, such as a
force push to `main` orphaning `github.event.before`, degrades to a full sweep
rather than silently skipping packages.

`mise.toml` deliberately does not force a full rebuild. CI installs no mise and
runs no mise task, so it cannot affect a build. Adding a mise step to the
workflow later means adding `mise\.toml` to `TOOLING_PATTERN`.

The README claimed that pushes to `main` were the only thing that publishes.
The guard is `github.event_name != 'pull_request' && github.ref == 'refs/heads/main'`,
so scheduled and manual runs on `main` publish too. Corrected here, since the
weekly run retrying a failed publish is part of why narrowing `main` is safe.
