### PR TITLE
fix(codex-desktop-git): conflict with openai-codex-desktop

### DIFF
--- a/packages/codex-desktop-git/PKGBUILD
+++ b/packages/codex-desktop-git/PKGBUILD
@@ -25,9 +25,10 @@ depends=(
     'xdg-utils'
     'hicolor-icon-theme'
     # Electron runtime libraries. Upstream's packaging/linux/PKGBUILD.template
-    # also lists atk, which Arch merged into at-spi2-core, and omits the direct
-    # links namcap reports against opt/codex-desktop/electron and the rebuilt
-    # native modules: expat, systemd-libs, gcc-libs and glibc.
+    # names atk, which still resolves because at-spi2-core provides it, but
+    # at-spi2-core is the package that actually exists. The template also omits
+    # the direct links namcap reports against opt/codex-desktop/electron and the
+    # rebuilt native modules: expat, systemd-libs, gcc-libs and glibc.
     'alsa-lib'
     'at-spi2-core'
     'cairo'
@@ -58,8 +59,10 @@ makedepends=(
     'python'
     'curl'
     'unzip'
-    # 7zip, not p7zip: upstream's check_deps rejects p7zip outright because it
-    # cannot read the APFS DMG the payload ships in.
+    # Upstream's template names p7zip here. Either resolves, since 7zip both
+    # provides and replaces it, but 7zip is the package that actually exists.
+    # The installer does refuse genuinely old p7zip builds, which cannot read
+    # the APFS DMG, and those are no longer installable on Arch anyway.
     '7zip'
     'nodejs'
     'npm'

--- a/packages/codex-desktop-git/PKGBUILD
+++ b/packages/codex-desktop-git/PKGBUILD
@@ -84,10 +84,15 @@ optdepends=(
 )
 # codex-desktop is upstream's own identity for the app: /opt/codex-desktop, the
 # Electron WM_CLASS, the ~/.config/codex-desktop settings directory, and the name
-# its deb, rpm and pacman packages all use. codex-desktop-linux is a separate AUR
-# package built from a soft-fork, and installs to the same paths.
+# its deb, rpm and pacman packages all use.
+#
+# The other two are separate AUR packagings of the same app that cannot be
+# co-installed. codex-desktop-linux builds from a soft-fork into the same paths.
+# openai-codex-desktop repackages the macOS archive and owns /usr/bin/codex-desktop
+# as well, but declares no provides, so the name has to be listed explicitly.
+# Listing it also covers chatgpt-desktop-bin, which provides and replaces it.
 provides=('codex-desktop')
-conflicts=('codex-desktop' 'codex-desktop-linux')
+conflicts=('codex-desktop' 'codex-desktop-linux' 'openai-codex-desktop')
 options=('!debug' '!strip')
 install="$pkgname.install"
 source=("$pkgname::git+https://github.com/ilysenko/codex-desktop-linux.git"


### PR DESCRIPTION
Declares a missing conflict, and corrects two dependency comments that overstated their reasoning. One file changed, `packages/codex-desktop-git/PKGBUILD`.

## Conflict with `openai-codex-desktop`

`openai-codex-desktop` is a separate AUR packaging of the same application, and it installs `/usr/bin/codex-desktop`, the same path this package owns. It declares no `provides`, so the existing `conflicts=('codex-desktop')` never matched it and the name has to be listed literally.

Without this, pacman had no way to know the two collide: installing one over the other would have failed part-way through the transaction on an existing-file error rather than being refused up front.

Listing the name also covers `chatgpt-desktop-bin`, which provides and replaces `openai-codex-desktop`. That package installs `/usr/bin/chatgpt-desktop` so it does not collide on files, but it is the same application and is not meant to be co-installed; it declares the same conflict itself.

`conflicts` becomes `('codex-desktop' 'codex-desktop-linux' 'openai-codex-desktop')`. `provides` is unchanged: adopting another packager's virtual name was not the goal here, only refusing a co-installation that cannot work.

## Dependency comments

Both comments claimed upstream's `packaging/linux/PKGBUILD.template` was wrong where it merely differs.

`atk` and `p7zip` both still resolve on current Arch: `at-spi2-core` provides `atk`, and `7zip` both provides and replaces `p7zip`. Depending on `at-spi2-core` and `7zip` is naming correctness, since Arch expects a dependency on the real package rather than on a virtual provide, not a fix for anything broken.

The `p7zip` comment additionally claimed upstream's `check_deps` "rejects p7zip outright". It rejects only genuinely old p7zip builds that cannot read APFS DMGs, and those are no longer installable on Arch.

## Validation

- The colliding path was read from the published `openai-codex-desktop` and `chatgpt-desktop-bin` PKGBUILDs rather than assumed.
- `pacman -T atk` and `pacman -Sp atk` confirm `atk` resolves through `at-spi2-core`; `pacman -Sp p7zip` resolves to `7zip`, which declares both `provides` and `replaces`.
- PKGBUILD parses and `.SRCINFO` regenerates with the three conflicts present.

No change to packaged output: the conflict is metadata, and the rest is comments.
