### PR TITLE
fix(renovate): scope postUpgradeTasks to PKGBUILD updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,14 +29,18 @@
       ]
     }
   },
-  "postUpgradeTasks": {
-    "commands": [
-      "bash scripts/refresh-sums.sh --reset-pkgrel {{{packageFileDir}}}"
-    ],
-    "fileFilters": ["packages/*/PKGBUILD"],
-    "executionMode": "update"
-  },
   "packageRules": [
+    {
+      "description": "Refresh checksums only for PKGBUILD updates; other managers must not trigger the script.",
+      "matchManagers": ["custom.regex"],
+      "postUpgradeTasks": {
+        "commands": [
+          "bash scripts/refresh-sums.sh --reset-pkgrel {{{packageFileDir}}}"
+        ],
+        "fileFilters": ["packages/*/PKGBUILD"],
+        "executionMode": "update"
+      }
+    },
     {
       "description": "Reproduce the '<pkgname>: update to <version>' convention, which the AUR publish step reuses verbatim as the AUR commit message. The version sits in commitMessageTopic because the components are joined prefix-action-topic-extra and commitMessage itself is deprecated.",
       "matchManagers": ["custom.regex"],


### PR DESCRIPTION
Top-level postUpgradeTasks ran for every manager, so a github-actions
update passed '.github/workflows' to refresh-sums.sh, which
allowedCommands rejects and Renovate reported as an artifact failure.
Scope the task to the custom.regex manager instead.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y995aCDEwakKPamDw43Fd3