### PR TITLE
codex-desktop-git: switch to official Linux deb, update to 26.814.41407

### DIFF
--- a/packages/codex-desktop-git/PKGBUILD
+++ b/packages/codex-desktop-git/PKGBUILD
@@ -4,42 +4,49 @@
 # Built from a rolling main branch, since upstream publishes neither releases
 # nor tags.
 #
-# pkgver carries the Codex app version on its own, and is the value Renovate
+# pkgver carries the ChatGPT app version on its own, and is the value Renovate
 # bumps. A pkgver() alone would not be enough: it only ever runs when somebody
 # rebuilds, so an installed copy is never told a newer app exists. Bumping this
 # line is what publishes an AUR revision that helpers surface to users, while
 # pkgver() below still stamps each build with what it actually produced.
 pkgname=codex-desktop-git
-pkgver=26.730.61639 # renovate: datasource=custom.codex-desktop-app depName=codex-desktop
+pkgver=26.814.41407 # renovate: datasource=deb depName=codex-desktop packageName=chatgpt registryUrl=https://persistent.oaistatic.com/codex-app-prod/linux/deb?suite=stable&components=main&binaryArch=amd64
 pkgrel=1
-pkgdesc='Unofficial ChatGPT desktop with built-in browser (ilysenko/codex-desktop-linux)'
+pkgdesc="Unofficial ChatGPT desktop repackaged from OpenAI's official Linux build (ilysenko/codex-desktop-linux)"
 arch=('x86_64')
 url='https://github.com/ilysenko/codex-desktop-linux'
-# MIT covers the Linux port. The macOS app it converts during build() remains
-# OpenAI's, is fetched from their CDN rather than redistributed here, and is not
-# covered by that MIT grant.
+# MIT covers the Linux repackaging. The app payload install.sh downloads is
+# OpenAI's official Linux package, fetched from their signed APT repository
+# rather than redistributed here, and is not covered by that MIT grant.
 license=('MIT' 'LicenseRef-OpenAI-Terms')
 depends=(
     'bash'
-    'python'
     'xdg-utils'
     'hicolor-icon-theme'
-    # Electron runtime libraries. Upstream's packaging/linux/PKGBUILD.template
-    # names atk, which still resolves because at-spi2-core provides it, but
-    # at-spi2-core is the package that actually exists. The template also omits
-    # the direct links namcap reports against opt/codex-desktop/electron and the
-    # rebuilt native modules: expat, systemd-libs, gcc-libs and glibc.
+    # Electron runtime libraries: the Depends field of the official deb, which
+    # ships in the payload as .codex-linux/upstream-package/control, mapped to
+    # Arch names. That field is authoritative where namcap is blind: Electron
+    # only dlopens libdrm, libglvnd, libnotify, libusb and xz, so namcap calls
+    # them unneeded. at-spi2-core is the package that provides the atk the deb
+    # names. gcc-libs and glibc are the direct links namcap reports. polkit,
+    # curl, dpkg, gnupg and nodejs serve only codex-update-manager, and
+    # package() stages the payload with PACKAGE_WITH_UPDATER=0, so nothing in
+    # it runs the updater.
     'alsa-lib'
     'at-spi2-core'
     'cairo'
     'dbus'
     'expat'
     'gcc-libs'
+    'gdk-pixbuf2'
     'glib2'
     'glibc'
     'gtk3'
     'libcups'
     'libdrm'
+    'libglvnd'
+    'libnotify'
+    'libusb'
     'libx11'
     'libxcb'
     'libxcomposite'
@@ -53,34 +60,25 @@ depends=(
     'nss'
     'pango'
     'systemd-libs'
+    'xz'
 )
 makedepends=(
     'git'
-    'python'
+    # install.sh check_deps requires node, curl, dpkg-deb, gpg and gpgv: the
+    # official payload is resolved from OpenAI's signed stable APT index and
+    # extracted from the deb it names.
     'curl'
-    'unzip'
-    # Upstream's template names p7zip here. Either resolves, since 7zip both
-    # provides and replaces it, but 7zip is the package that actually exists.
-    # The installer does refuse genuinely old p7zip builds, which cannot read
-    # the APFS DMG, and those are no longer installable on Arch anyway.
-    '7zip'
+    'dpkg'
+    'gnupg'
     'nodejs'
-    'npm'
-    # The notification action bridge, the Chrome extension host and the Computer
-    # Use plugin are Rust, and the installer builds each of them only if it finds
-    # cargo, warning and carrying on when it does not. Leaving this out therefore
-    # does not fail the build, it silently ships a package whose contents depend
-    # on whether the build host happened to have Rust installed.
-    'cargo'
+    # The transactional candidate promotion in install.sh runs
+    # scripts/lib/candidate-promotion.py, and pkgver() reads build-info.json.
+    'python'
 )
 optdepends=(
-    'nodejs: override the bundled managed Node.js runtime'
-    'npm: Codex CLI install and update flows'
-    'zenity: GTK dialog fallback when the Codex CLI is missing'
-    'kdialog: KDE dialog fallback when the Codex CLI is missing'
-    'ydotool: synthetic keyboard and pointer input for Computer Use on Wayland'
-    'xdg-desktop-portal-wlr: screenshot and remote desktop portal for wlroots'
-    'xdg-desktop-portal-gnome: screenshot and remote desktop portal for GNOME'
+    'git: project source control integration'
+    'pulseaudio: audio integration'
+    'apparmor: confine the ChatGPT binary with the shipped profile'
 )
 # codex-desktop is upstream's own identity for the app: /opt/codex-desktop, the
 # Electron WM_CLASS, the ~/.config/codex-desktop settings directory, and the name
@@ -106,44 +104,28 @@ sha256sums=('SKIP'
 prepare() {
     cd "$pkgname"
 
-    # Electron and the managed Node runtime arrive prebuilt. makepkg's default
-    # flags do not match their ABI and break the native module rebuild.
-    unset CFLAGS CXXFLAGS LDFLAGS
-
-    # install.sh writes a job summary and run metadata into the DMG acceptance
-    # report whenever it finds these set. Under a container build action the
-    # runner's summary file is present in the environment but owned by another
-    # user, so the write fails with EACCES and takes the build down with it.
-    unset GITHUB_STEP_SUMMARY GITHUB_RUN_ID GITHUB_RUN_ATTEMPT \
-        GITHUB_SERVER_URL GITHUB_REPOSITORY
-
-    # The installer fetches the macOS payload, an Electron runtime, a managed
-    # Node runtime and npm modules. Its caches default to the caller's home, so
-    # redirect them into srcdir while still honouring a warm cache if set.
+    # install.sh fetches OpenAI's official Linux deb from their signed APT
+    # repository, verifies it, and stages the patched app tree here.
     export CODEX_INSTALL_DIR="$srcdir/codex-app"
-    export CODEX_MANAGED_NODE_CACHE_DIR="${CODEX_MANAGED_NODE_CACHE_DIR:-$srcdir/cache/node-runtime}"
-    export CODEX_ELECTRON_CACHE_DIR="${CODEX_ELECTRON_CACHE_DIR:-$srcdir/cache/electron}"
-    export CODEX_BROWSER_USE_RUNTIME_CACHE_DIR="${CODEX_BROWSER_USE_RUNTIME_CACHE_DIR:-$srcdir/cache/browser-use}"
-    export MAX_BUILD_THREADS="$(nproc)"
 
     ./install.sh
 }
 
-# Reports the version of the app that was actually built, from the
-# CFBundleShortVersionString install.sh recorded for the payload it downloaded.
+# Reports the version of the app that was actually built, from the deb Version
+# install.sh recorded for the official Linux package it downloaded.
 #
 # Deliberately does not derive from $pkgver: makepkg rewrites the pkgver= line
 # with whatever this returns, so appending to the previous value would compound
-# the .rN.gSHA suffix on every rebuild. The pkgver= line above stays the Codex
+# the .rN.gSHA suffix on every rebuild. The pkgver= line above stays the ChatGPT
 # app version alone, which is what Renovate bumps and what reaches users as an
 # AUR revision; makepkg's rewrite preserves its trailing annotation.
 pkgver() {
     local _appver
     _appver=$(python -c '
 import json, sys
-version = json.load(open(sys.argv[1]))["upstreamDmg"]["appVersion"]
+version = json.load(open(sys.argv[1]))["upstreamLinuxPackage"]["version"]
 if not version:
-    raise SystemExit("build-info.json recorded no upstreamDmg.appVersion")
+    raise SystemExit("build-info.json recorded no upstreamLinuxPackage.version")
 print(version)
 ' "$srcdir/codex-app/.codex-linux/build-info.json")
 

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/(^|/)PKGBUILD$/"],
       "matchStrings": [
-        "pkgver=(?<currentValue>\\S+)[ \\t]*#[ \\t]*renovate:[ \\t]*datasource=(?<datasource>\\S+)[ \\t]+depName=(?<depName>\\S+)(?:[ \\t]+packageName=(?<packageName>\\S+))?(?:[ \\t]+versioning=(?<versioning>\\S+))?"
+        "pkgver=(?<currentValue>\\S+)[ \\t]*#[ \\t]*renovate:[ \\t]*datasource=(?<datasource>\\S+)[ \\t]+depName=(?<depName>\\S+)(?:[ \\t]+packageName=(?<packageName>\\S+))?(?:[ \\t]+versioning=(?<versioning>\\S+))?(?:[ \\t]+registryUrl=(?<registryUrl>\\S+))?"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}loose{{/if}}"
     }
@@ -18,14 +18,6 @@
       "format": "json",
       "transformTemplates": [
         "{\"releases\":[{\"version\": pkgver, \"releaseTimestamp\": last_update, \"sourceUrl\": url}], \"homepage\": url, \"sourceUrl\": url}"
-      ]
-    },
-    "codex-desktop-app": {
-      "description": "Codex desktop app releases. OpenAI publishes only a Sparkle appcast, which is XML and so unreadable by a custom datasource; this community mirror restates the same feed as JSON. Only the version is taken from it, and the arm64 short version is the one to read: it is what the payload install.sh downloads reports as its CFBundleShortVersionString.",
-      "defaultRegistryUrlTemplate": "https://codexapp.agentsmirror.com/latest/manifest",
-      "format": "json",
-      "transformTemplates": [
-        "{\"releases\":[{\"version\": sources.macos.arm64.appcast.shortVersionString}], \"homepage\": \"https://github.com/ilysenko/codex-desktop-linux\"}"
       ]
     }
   },


### PR DESCRIPTION
## What changed

Upstream ilysenko/codex-desktop-linux now builds the app from OpenAI's official Linux package instead of converting the macOS DMG: `install.sh` resolves the `chatgpt` deb from OpenAI's signed stable APT repository, verifies it with gpg, extracts it with `dpkg-deb`, and stages a patched app tree. This PR adapts the PKGBUILD and Renovate configuration to that build process.

### PKGBUILD

- `makedepends`: `git curl dpkg gnupg nodejs python`, matching `install.sh` `check_deps` (node, curl, dpkg-deb, gpg, gpgv) plus python for the transactional candidate promotion and `pkgver()`. `7zip`, `unzip`, `npm` and `cargo` are not needed: there is no DMG to unpack, and the Rust components are either opt-in linux-features (disabled) or the updater (excluded via `PACKAGE_WITH_UPDATER=0`).
- `depends`: derived from the official deb's `Depends` field mapped to Arch names. Adds `gdk-pixbuf2 libglvnd libnotify libusb xz`, drops `python` and the updater-only entries. The deb's control file ships in the payload for cross-checking.
- `prepare()`: exports `CODEX_INSTALL_DIR` and runs `./install.sh`. The flag unsets, `GITHUB_*` unsets and cache-dir exports referenced installer code that no longer exists.
- `pkgver()`: reads `upstreamLinuxPackage.version` from build-info.json; the pkgver line is bumped to 26.814.41407, the version the build produces today.
- `pkgdesc` and license comments reworded for the Linux payload; `optdepends` now mirrors the deb's Recommends (git, pulseaudio) plus apparmor for the shipped profile.
- `package()` is unchanged: upstream's staging library keeps the same contract, and the `.install` hooks still match the generated no-updater hooks.

### Renovate

- The pkgver line now uses the built-in `deb` datasource against OpenAI's APT repository (`packageName=chatgpt`, suite `stable`), replacing the `codex-desktop-app` Sparkle-appcast mirror datasource, which is removed.
- The regex manager gains an optional `registryUrl` capture group.

## Validation

- Full local `makepkg` build succeeded end to end (26.814.41407.r2034.g2078f4da), producing a working package; namcap dependency findings cross-checked against the deb's `Depends` field. Remaining namcap warnings are bundled prebuilds for other platforms (android/arm/musl/darwin) and are not actionable.
- Renovate dry run (`--platform=local`) confirmed the deb datasource fetches `Packages.gz` from the OpenAI repository and resolves `chatgpt` 26.814.41407 as current, with no spurious update.

## Notes

- This supersedes the Renovate PR #18, whose CI fails in `prepare()` because the previous PKGBUILD lacks `dpkg`; it can be closed once this merges. Closes #18 